### PR TITLE
fix: サーバー起動するポート番号を環境変数から読み取るように変更

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -97,5 +97,7 @@ func main() {
 	itemController := itemController.NewItemController(itemUsecase)
 
 	e := router.NewRouter(userController, categoryController, boxController, patternController, itemController)
-	e.Logger.Fatal(e.Start(":8080"))
+
+	port := os.Getenv("PORT")
+	e.Logger.Fatal(e.Start(":" + port))
 }


### PR DESCRIPTION
## 概要
サーバー起動のポート番号が8080でハードコードされているのを、環境変数から読み取るように変更。