### PR TITLE
Bug/#164/regenerate dates

### DIFF
--- a/domain/item/item.go
+++ b/domain/item/item.go
@@ -270,5 +270,6 @@ type IScheduler interface {
 		boxID *string,
 		itemID string,
 		parsedLearnedDate time.Time,
+		diff time.Duration,
 	) ([]*Reviewdate, error)
 }

--- a/domain/item/mock_item.go
+++ b/domain/item/mock_item.go
@@ -104,16 +104,16 @@ func (mr *MockISchedulerMockRecorder) FormatWithOverdueMarkedInCompletedWithIDs(
 }
 
 // FormatWithOverdueMarkedInCompletedWithIDsForBackReviewDates mocks base method.
-func (m *MockIScheduler) FormatWithOverdueMarkedInCompletedWithIDsForBackReviewDates(targetPatternSteps []*pattern.PatternStep, reviewDateIDs []string, userID string, categoryID, boxID *string, itemID string, parsedLearnedDate time.Time) ([]*Reviewdate, error) {
+func (m *MockIScheduler) FormatWithOverdueMarkedInCompletedWithIDsForBackReviewDates(targetPatternSteps []*pattern.PatternStep, reviewDateIDs []string, userID string, categoryID, boxID *string, itemID string, parsedLearnedDate time.Time, diff time.Duration) ([]*Reviewdate, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FormatWithOverdueMarkedInCompletedWithIDsForBackReviewDates", targetPatternSteps, reviewDateIDs, userID, categoryID, boxID, itemID, parsedLearnedDate)
+	ret := m.ctrl.Call(m, "FormatWithOverdueMarkedInCompletedWithIDsForBackReviewDates", targetPatternSteps, reviewDateIDs, userID, categoryID, boxID, itemID, parsedLearnedDate, diff)
 	ret0, _ := ret[0].([]*Reviewdate)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FormatWithOverdueMarkedInCompletedWithIDsForBackReviewDates indicates an expected call of FormatWithOverdueMarkedInCompletedWithIDsForBackReviewDates.
-func (mr *MockISchedulerMockRecorder) FormatWithOverdueMarkedInCompletedWithIDsForBackReviewDates(targetPatternSteps, reviewDateIDs, userID, categoryID, boxID, itemID, parsedLearnedDate any) *gomock.Call {
+func (mr *MockISchedulerMockRecorder) FormatWithOverdueMarkedInCompletedWithIDsForBackReviewDates(targetPatternSteps, reviewDateIDs, userID, categoryID, boxID, itemID, parsedLearnedDate, diff any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FormatWithOverdueMarkedInCompletedWithIDsForBackReviewDates", reflect.TypeOf((*MockIScheduler)(nil).FormatWithOverdueMarkedInCompletedWithIDsForBackReviewDates), targetPatternSteps, reviewDateIDs, userID, categoryID, boxID, itemID, parsedLearnedDate)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FormatWithOverdueMarkedInCompletedWithIDsForBackReviewDates", reflect.TypeOf((*MockIScheduler)(nil).FormatWithOverdueMarkedInCompletedWithIDsForBackReviewDates), targetPatternSteps, reviewDateIDs, userID, categoryID, boxID, itemID, parsedLearnedDate, diff)
 }

--- a/domain/item/review_scheduler.go
+++ b/domain/item/review_scheduler.go
@@ -222,8 +222,8 @@ func (s *scheduler) FormatWithOverdueMarkedInCompletedWithIDsForBackReviewDates(
 			boxID,
 			itemID,
 			step.StepNumber,
-			calculatedScheduledDate,
 			calculatedScheduledDate.Add(-diff),
+			calculatedScheduledDate,
 			false, // 全部未完了扱い
 		)
 		if err != nil {

--- a/domain/item/review_scheduler.go
+++ b/domain/item/review_scheduler.go
@@ -204,6 +204,7 @@ func (s *scheduler) FormatWithOverdueMarkedInCompletedWithIDsForBackReviewDates(
 	boxID *string,
 	itemID string,
 	parsedLearnedDate time.Time,
+	diff time.Duration,
 ) ([]*Reviewdate, error) {
 	if len(reviewDateIDs) != len(targetPatternSteps) {
 		return nil, ErrNewScheduledDateBeforeInitialScheduledDate
@@ -222,7 +223,7 @@ func (s *scheduler) FormatWithOverdueMarkedInCompletedWithIDsForBackReviewDates(
 			itemID,
 			step.StepNumber,
 			calculatedScheduledDate,
-			calculatedScheduledDate,
+			calculatedScheduledDate.Add(-diff),
 			false, // 全部未完了扱い
 		)
 		if err != nil {

--- a/domain/item/review_scheduler_test.go
+++ b/domain/item/review_scheduler_test.go
@@ -666,8 +666,8 @@ func TestFormatWithOverdueMarkedInCompletedWithIDsForBackReviewDates(t *testing.
 				}
 
 				expectedScheduledDate := tt.parsedLearnedDate.AddDate(0, 0, tt.targetPatternSteps[i].IntervalDays).Add(-tt.diff)
-				if !rd.ScheduledDate.Equal(expectedScheduledDate) {
-					t.Errorf("FormatWithOverdueMarkedInCompletedWithIDsForBackReviewDates() reviewdate[%d].ScheduledDate = %v, want %v", i, rd.ScheduledDate, expectedScheduledDate)
+				if !rd.InitialScheduledDate.Equal(expectedScheduledDate) {
+					t.Errorf("FormatWithOverdueMarkedInCompletedWithIDsForBackReviewDates() reviewdate[%d].InitialScheduledDate = %v, want %v", i, rd.InitialScheduledDate, expectedScheduledDate)
 				}
 
 				if rd.IsCompleted != false {

--- a/domain/item/review_scheduler_test.go
+++ b/domain/item/review_scheduler_test.go
@@ -552,7 +552,7 @@ func TestFormatWithOverdueMarkedInCompletedWithIDsForBackReviewDates(t *testing.
 		boxID              *string
 		itemID             string
 		parsedLearnedDate  time.Time
-		parsedToday        time.Time
+		diff               time.Duration
 		wantReviewdatesLen int
 		wantError          bool
 		wantErrorType      error
@@ -569,7 +569,23 @@ func TestFormatWithOverdueMarkedInCompletedWithIDsForBackReviewDates(t *testing.
 			boxID:              stringPtr("box123"),
 			itemID:             "item123",
 			parsedLearnedDate:  time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
-			parsedToday:        time.Date(2024, 1, 5, 0, 0, 0, 0, time.UTC),
+			diff:               0,
+			wantReviewdatesLen: 2,
+			wantError:          false,
+		},
+		{
+			name: "diffが設定されている場合",
+			targetPatternSteps: []*PatternDomain.PatternStep{
+				{StepNumber: 1, IntervalDays: 1},
+				{StepNumber: 2, IntervalDays: 3},
+			},
+			reviewDateIDs:      []string{"rd1", "rd2"},
+			userID:             "user123",
+			categoryID:         stringPtr("cat123"),
+			boxID:              stringPtr("box123"),
+			itemID:             "item123",
+			parsedLearnedDate:  time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+			diff:               24 * time.Hour * 2,
 			wantReviewdatesLen: 2,
 			wantError:          false,
 		},
@@ -585,7 +601,7 @@ func TestFormatWithOverdueMarkedInCompletedWithIDsForBackReviewDates(t *testing.
 			boxID:              stringPtr("box123"),
 			itemID:             "item123",
 			parsedLearnedDate:  time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
-			parsedToday:        time.Date(2024, 1, 5, 0, 0, 0, 0, time.UTC),
+			diff:               0,
 			wantReviewdatesLen: 0,
 			wantError:          true,
 			wantErrorType:      ErrNewScheduledDateBeforeInitialScheduledDate,
@@ -599,7 +615,7 @@ func TestFormatWithOverdueMarkedInCompletedWithIDsForBackReviewDates(t *testing.
 			boxID:              nil,
 			itemID:             "item123",
 			parsedLearnedDate:  time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
-			parsedToday:        time.Date(2024, 1, 5, 0, 0, 0, 0, time.UTC),
+			diff:               0,
 			wantReviewdatesLen: 0,
 			wantError:          false,
 		},
@@ -615,6 +631,7 @@ func TestFormatWithOverdueMarkedInCompletedWithIDsForBackReviewDates(t *testing.
 				tt.boxID,
 				tt.itemID,
 				tt.parsedLearnedDate,
+				tt.diff,
 			)
 
 			if (err != nil) != tt.wantError {
@@ -648,7 +665,7 @@ func TestFormatWithOverdueMarkedInCompletedWithIDsForBackReviewDates(t *testing.
 					t.Errorf("FormatWithOverdueMarkedInCompletedWithIDsForBackReviewDates() reviewdate[%d].ItemID = %v, want %v", i, rd.ItemID, tt.itemID)
 				}
 
-				expectedScheduledDate := tt.parsedLearnedDate.AddDate(0, 0, tt.targetPatternSteps[i].IntervalDays)
+				expectedScheduledDate := tt.parsedLearnedDate.AddDate(0, 0, tt.targetPatternSteps[i].IntervalDays).Add(-tt.diff)
 				if !rd.ScheduledDate.Equal(expectedScheduledDate) {
 					t.Errorf("FormatWithOverdueMarkedInCompletedWithIDsForBackReviewDates() reviewdate[%d].ScheduledDate = %v, want %v", i, rd.ScheduledDate, expectedScheduledDate)
 				}

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/docker/docker v27.2.0+incompatible // indirect
 	github.com/docker/go-connections v0.5.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
-	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
+	github.com/go-viper/mapstructure/v2 v2.3.0 // indirect
 	github.com/goccy/go-yaml v1.17.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/go-testfixtures/testfixtures/v3 v3.16.0 h1:bSjH1206tTSXSQZLtUjLvy6sbS
 github.com/go-testfixtures/testfixtures/v3 v3.16.0/go.mod h1:fH6IT/2lM5yV5cuTkPkuQv3f6JW+AE9tMUovxUhWUhE=
 github.com/go-viper/mapstructure/v2 v2.2.1 h1:ZAaOCxANMuZx5RCeg0mBdEZk7DZasvvZIxtHqx8aGss=
 github.com/go-viper/mapstructure/v2 v2.2.1/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
+github.com/go-viper/mapstructure/v2 v2.3.0 h1:27XbWsHIqhbdR5TIC911OfYvgSaW93HM+dX7970Q7jk=
+github.com/go-viper/mapstructure/v2 v2.3.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/goccy/go-yaml v1.17.1 h1:LI34wktB2xEE3ONG/2Ar54+/HJVBriAGJ55PHls4YuY=
 github.com/goccy/go-yaml v1.17.1/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=

--- a/infrastructure/db/dbgen/item.sql.go
+++ b/infrastructure/db/dbgen/item.sql.go
@@ -1602,12 +1602,13 @@ UPDATE review_dates r
 SET
     category_id = v.category_id,
     box_id = v.box_id,
+    initial_scheduled_date = v.initial_scheduled_date,
     scheduled_date = v.scheduled_date,
     is_completed = v.is_completed
 FROM
     UNNEST(
         $2::back_reviewdate_input[]
-    ) AS v(id, category_id, box_id, scheduled_date, is_completed)
+    ) AS v(id, category_id, box_id, initial_scheduled_date, scheduled_date, is_completed)
 WHERE
     r.id = v.id
 AND

--- a/infrastructure/db/query/item.sql
+++ b/infrastructure/db/query/item.sql
@@ -143,12 +143,13 @@ UPDATE review_dates r
 SET
     category_id = v.category_id,
     box_id = v.box_id,
+    initial_scheduled_date = v.initial_scheduled_date,
     scheduled_date = v.scheduled_date,
     is_completed = v.is_completed
 FROM
     UNNEST(
         sqlc.arg(input)::back_reviewdate_input[]
-    ) AS v(id, category_id, box_id, scheduled_date, is_completed)
+    ) AS v(id, category_id, box_id, initial_scheduled_date, scheduled_date, is_completed)
 WHERE
     r.id = v.id
 AND

--- a/infrastructure/repository/item_repository.go
+++ b/infrastructure/repository/item_repository.go
@@ -308,7 +308,7 @@ func (r *itemRepository) UpdateReviewDatesBack(ctx context.Context, reviewdates 
 		if rd.BoxID != nil {
 			boxID = *rd.BoxID
 		}
-		inputs[i] = fmt.Sprintf("(%s,%s,%s,%s,%t)", rd.ReviewdateID, categoryID, boxID, rd.ScheduledDate.Format("2006-01-02"), rd.IsCompleted)
+		inputs[i] = fmt.Sprintf("(%s,%s,%s,%s,%s,%t)", rd.ReviewdateID, categoryID, boxID, rd.InitialScheduledDate.Format("2006-01-02"), rd.ScheduledDate.Format("2006-01-02"), rd.IsCompleted)
 	}
 
 	params := dbgen.UpdateReviewDatesBackParams{

--- a/infrastructure/repository/item_repository_test.go
+++ b/infrastructure/repository/item_repository_test.go
@@ -630,7 +630,7 @@ func TestItemRepository_UpdateReviewDatesBack(t *testing.T) {
 					BoxID:                stringPtr("950e8400-e29b-41d4-a716-446655440001"),
 					ItemID:               "a50e8400-e29b-41d4-a716-446655440001",
 					StepNumber:           2,
-					InitialScheduledDate: time.Date(2024, 1, 4, 0, 0, 0, 0, time.UTC),
+					InitialScheduledDate: time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC),
 					ScheduledDate:        time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC), // 巻き戻されたスケジュール日
 					IsCompleted:          false,
 				},
@@ -644,7 +644,7 @@ func TestItemRepository_UpdateReviewDatesBack(t *testing.T) {
 					BoxID:                stringPtr("950e8400-e29b-41d4-a716-446655440001"),
 					ItemID:               "a50e8400-e29b-41d4-a716-446655440001",
 					StepNumber:           2,
-					InitialScheduledDate: time.Date(2024, 1, 4, 0, 0, 0, 0, time.UTC),
+					InitialScheduledDate: time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC),
 					ScheduledDate:        time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC),
 					IsCompleted:          false,
 				},

--- a/migrations/000013_recreateback_reviewdate_input_type.down.sql
+++ b/migrations/000013_recreateback_reviewdate_input_type.down.sql
@@ -1,0 +1,10 @@
+DROP TYPE IF EXISTS back_reviewdate_input;
+
+-- 古い定義(000012)で複合型を再作成 (initial_scheduled_dateなし)
+CREATE TYPE back_reviewdate_input AS (
+    id uuid,
+    category_id uuid,
+    box_id uuid,
+    scheduled_date date,
+    is_completed boolean
+);

--- a/migrations/000013_recreateback_reviewdate_input_type.up.sql
+++ b/migrations/000013_recreateback_reviewdate_input_type.up.sql
@@ -1,0 +1,11 @@
+DROP TYPE IF EXISTS back_reviewdate_input;
+
+-- 複合型を再作成
+CREATE TYPE back_reviewdate_input AS (
+    id uuid,
+    category_id uuid,
+    box_id uuid,
+    initial_scheduled_date date,
+    scheduled_date date,
+    is_completed boolean
+);

--- a/usecase/item/item_usecase.go
+++ b/usecase/item/item_usecase.go
@@ -623,8 +623,9 @@ func (iu *ItemUsecase) UpdateReviewDates(ctx context.Context, input UpdateBackRe
 				}
 			}
 			calculatedNextScheduledDate := FakeLearnedDate.AddDate(0, 0, nextIntervalDays)
+			var diff time.Duration
 			if calculatedNextScheduledDate.Before(parsedToday) {
-				diff := parsedToday.Sub(calculatedNextScheduledDate)
+				diff = parsedToday.Sub(calculatedNextScheduledDate)
 				FakeLearnedDate = FakeLearnedDate.AddDate(0, 0, int(diff.Hours()/24))
 			}
 			newReviewdates, err = iu.scheduler.FormatWithOverdueMarkedInCompletedWithIDsForBackReviewDates(
@@ -635,6 +636,7 @@ func (iu *ItemUsecase) UpdateReviewDates(ctx context.Context, input UpdateBackRe
 				input.BoxID,
 				input.ItemID,
 				FakeLearnedDate,
+				diff,
 			)
 			if err != nil {
 				return nil, err

--- a/usecase/item/item_usecase_test.go
+++ b/usecase/item/item_usecase_test.go
@@ -2524,6 +2524,7 @@ func TestItemUsecase_UpdateReviewDates(t *testing.T) {
 						&boxID,
 						itemID,
 						gomock.Any(),
+						gomock.Any(),
 					).Return(testNewReviewdates, nil).Times(1),
 					mockItemRepo.EXPECT().GetEditedAtByItemID(ctx, itemID, userID).Return(editedAt, nil).Times(1),
 					mockItemRepo.EXPECT().UpdateReviewDatesBack(ctx, gomock.Any(), userID).Return(nil).Times(1),


### PR DESCRIPTION
## 概要
/usecase/item/item_usecase.goのUpdateReviewDatesでi!isLastStepかつ!input.IsMarkOverdueAsCompletedのとき、nitial_scheduled_dateが正常に生成されていない不具合を修正。

## 変更内容
### review_scheduler.go
1.  **ロジック修正**
    - NewReviewdateの引数であるinitialScheduledDateにscheduledDateと同じ値を渡していたため、calculatedScheduledDate.Add(-diff)のようにしてdiffの値が1以上の場合（後続の復習日が今日より前のとき）を考慮したinitialScheduledDateを渡すように修正。
2. **クエリ修正**
    - UpdateReviewDatesBackでinitial_scheduled_dateを更新するように修正。
      - initial_scheduled_dateは複合型で渡されているため、その複合型（back_reviewdate_input）も修正。
      - back_reviewdate_inputはALTER TYPEせず削除して再作成する形にした。
        - ALTER TYPEでsqlc generateすると既存のback_reviewdate_inputを存在しないと判定するエラーが発生していて、同様の現象が[イシュー](https://github.com/sqlc-dev/sqlc/issues/3997)としてあった。back_reviewdate_inputはクエリ発行時の一時的なデータ解釈としてしか使っていないので削除して作成しなおすマイグレーションを追加で対処。

## 関連
PR #166 from issue #165