### PR TITLE
fix: users.timezoneの型をtimezone VARCHAR(32))に変更

### DIFF
--- a/migrations/000014_ALTER_COLUMN_users_timezone.down.sql
+++ b/migrations/000014_ALTER_COLUMN_users_timezone.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users
+    ALTER COLUMN timezone TYPE VARCHAR(64);

--- a/migrations/000014_ALTER_COLUMN_users_timezone.up.sql
+++ b/migrations/000014_ALTER_COLUMN_users_timezone.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users
+    ALTER COLUMN timezone TYPE VARCHAR(32);


### PR DESCRIPTION
## 概要
users.timezoneの型をtimezone VARCHAR(32))に変更。